### PR TITLE
Grampachayid page and menu fix

### DIFF
--- a/app/api/admin/users/register/route.ts
+++ b/app/api/admin/users/register/route.ts
@@ -61,8 +61,7 @@ export async function POST(request: NextRequest) {
     if (session.user.role === "ADMIN") {
       const adminGpId =
         session.user.gramPanchayat?.id ||
-        session.user.gramPanchayatId ||
-        session.user.gpId;
+        session.user.gramPanchayatId;
       if (!adminGpId || adminGpId !== gramPanchayatId) {
         return NextResponse.json(
           {

--- a/constants/menu-constants.ts
+++ b/constants/menu-constants.ts
@@ -59,7 +59,7 @@ const COLORS = {
 const BASE_URLS = {
   ADMIN: "/admin",
   STAFF: "/staff",
-  SUPER_ADMIN: "/dashboard",
+  SUPER_ADMIN: "/super-admin",
 };
 
 // Enhanced helper to create menu items with allowedRoles


### PR DESCRIPTION
Fix menu rendering and navigation for all roles, and standardize `gramPanchayatId` usage.

This PR removes inconsistent `gpId` usage in the admin registration API, normalizes role mapping in the `UnifiedSidebar` to derive roles from the session, and updates the Super Admin menu base path to `/super-admin` to ensure menu links match actual routes.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6ff1b18-497f-4755-a6e6-690c9f80d65e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6ff1b18-497f-4755-a6e6-690c9f80d65e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

